### PR TITLE
create local_internal_options.conf file only if it does not exist ( D…

### DIFF
--- a/cookbooks/wazuh_agent/recipes/agent.rb
+++ b/cookbooks/wazuh_agent/recipes/agent.rb
@@ -109,7 +109,7 @@ template "#{node['ossec']['dir']}/etc/local_internal_options.conf" do
   source 'var/ossec/etc/agent_local_internal_options.conf'
   owner 'root'
   group 'wazuh'
-  action :create
+  only_if { !::File.exist?("#{node['ossec']['dir']}/etc/local_internal_options.conf") }
 end
 
 service 'wazuh' do


### PR DESCRIPTION
 DO NOT OVERRIDE USER DEFINED CONTENTS 

[Internal configuration - Reference · Wazuh documentation](https://documentation.wazuh.com/current/user-manual/reference/internal-options.html)

> Warning This file will be overwritten during upgrades. In order to maintain custom changes, you must use the /var/ossec/etc/local_internal_options.conf file.
