### PR TITLE
Bump release v4.11.1

### DIFF
--- a/cookbooks/wazuh_agent/attributes/version.rb
+++ b/cookbooks/wazuh_agent/attributes/version.rb
@@ -4,4 +4,4 @@
 
 default['wazuh']['major_version'] = "4.x"
 default['wazuh']['minor_version'] = "4.11"
-default['wazuh']['patch_version'] = "4.11.0"
+default['wazuh']['patch_version'] = "4.11.1"

--- a/cookbooks/wazuh_manager/attributes/versions.rb
+++ b/cookbooks/wazuh_manager/attributes/versions.rb
@@ -4,4 +4,4 @@
 
 default['wazuh']['major_version'] = "4.x"
 default['wazuh']['minor_version'] = "4.11"
-default['wazuh']['patch_version'] = "4.11.0"
+default['wazuh']['patch_version'] = "4.11.1"


### PR DESCRIPTION
[4.11.1 Release notes - 12 March 2025 - 4.x · Wazuh documentation](https://documentation.wazuh.com/current/release-notes/release-4-11-1.html)