### PR TITLE
 Bump release 4.11.2

### DIFF
--- a/cookbooks/wazuh_agent/attributes/version.rb
+++ b/cookbooks/wazuh_agent/attributes/version.rb
@@ -4,4 +4,4 @@
 
 default['wazuh']['major_version'] = "4.x"
 default['wazuh']['minor_version'] = "4.11"
-default['wazuh']['patch_version'] = "4.11.1"
+default['wazuh']['patch_version'] = "4.11.2"

--- a/cookbooks/wazuh_manager/attributes/versions.rb
+++ b/cookbooks/wazuh_manager/attributes/versions.rb
@@ -4,4 +4,4 @@
 
 default['wazuh']['major_version'] = "4.x"
 default['wazuh']['minor_version'] = "4.11"
-default['wazuh']['patch_version'] = "4.11.1"
+default['wazuh']['patch_version'] = "4.11.2"


### PR DESCRIPTION
[4.11.2 Release notes - 1 April 2025 - 4.x · Wazuh documentation](https://documentation.wazuh.com/current/release-notes/release-4-11-2.html)