### PR TITLE
Bump release 4.14.4

### DIFF
--- a/cookbooks/wazuh_agent/attributes/version.rb
+++ b/cookbooks/wazuh_agent/attributes/version.rb
@@ -3,5 +3,5 @@
 # Author:: Wazuh <info@wazuh.com
 
 default['wazuh']['major_version'] = "4.x"
-default['wazuh']['minor_version'] = "4.13"
-default['wazuh']['patch_version'] = "4.13.1"
+default['wazuh']['minor_version'] = "4.14"
+default['wazuh']['patch_version'] = "4.14.4"

--- a/cookbooks/wazuh_manager/attributes/versions.rb
+++ b/cookbooks/wazuh_manager/attributes/versions.rb
@@ -3,5 +3,5 @@
 # Author:: Wazuh <info@wazuh.com
 
 default['wazuh']['major_version'] = "4.x"
-default['wazuh']['minor_version'] = "4.13"
-default['wazuh']['patch_version'] = "4.13.1"
+default['wazuh']['minor_version'] = "4.14"
+default['wazuh']['patch_version'] = "4.14.4"


### PR DESCRIPTION
## What

Update Wazuh to the latest release 4.14.4 (released 2026-03-17).

## Why

Keep wazuh_manager and wazuh_agent cookbooks up to date with the latest Wazuh release.

## How

- Update `patch_version` from 4.13.1 to 4.14.4 in wazuh_manager and wazuh_agent attributes.

Release notes: https://documentation.wazuh.com/current/release-notes/index.html

🤖 Generated with [Claude Code](https://claude.ai/code)