### PR TITLE
Add malicious-ioc CDB lists to ruleset config

### DIFF
--- a/cookbooks/wazuh_manager/attributes/ruleset.rb
+++ b/cookbooks/wazuh_manager/attributes/ruleset.rb
@@ -14,8 +14,11 @@ default['ossec']['conf']['ruleset'] = {
     ],
     'rule_exclude' => '0215-policy_rules.xml',
     'list' => [
-        'etc/lists/audit-keys', 
-        'etc/lists/security-eventchannel', 
-        'etc/lists/amazon/aws-eventnames'
+        'etc/lists/audit-keys',
+        'etc/lists/security-eventchannel',
+        'etc/lists/amazon/aws-eventnames',
+        'etc/lists/malicious-ioc/malware-hashes',
+        'etc/lists/malicious-ioc/malicious-ip',
+        'etc/lists/malicious-ioc/malicious-domains'
     ]
 }


### PR DESCRIPTION
## What

Add three CDB (Constant Database) lists for malicious IoC detection to the Manager ruleset configuration.

## Why

Wazuh 4.12.0 introduced built-in CDB lists for malware hashes, malicious IPs, and malicious domains. Without referencing them in the `<ruleset>` section, the detection rules that rely on these lists will not function.

## How

Add the following entries to `attributes/ruleset.rb` list array:
- `etc/lists/malicious-ioc/malware-hashes`
- `etc/lists/malicious-ioc/malicious-ip`
- `etc/lists/malicious-ioc/malicious-domains`

🤖 Generated with [Claude Code](https://claude.ai/code)