### PR TITLE
Add enrollment subsection to agent client config

### DIFF
--- a/cookbooks/wazuh_agent/attributes/client.rb
+++ b/cookbooks/wazuh_agent/attributes/client.rb
@@ -7,3 +7,10 @@ default['ossec']['conf']['client']['notify_time'] = 10
 default['ossec']['conf']['client']['time-reconnect'] = 60
 default['ossec']['conf']['client']['auto_restart'] = true
 default['ossec']['conf']['client']['crypto_method'] = "aes"
+
+# Enrollment configuration (ossec.conf <client> -> <enrollment>)
+# https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/client.html
+default['ossec']['conf']['client']['enrollment']['enabled'] = true
+default['ossec']['conf']['client']['enrollment']['manager_address'] = node['ossec']['address']
+default['ossec']['conf']['client']['enrollment']['port'] = 1515
+default['ossec']['conf']['client']['enrollment']['agent_name'] = node['hostname']


### PR DESCRIPTION
## What

Add `<enrollment>` configuration subsection to the agent's `<client>` section.

## Why

Since Wazuh 4.0, agents register automatically via the enrollment mechanism instead of the legacy agent-auth command. The enrollment settings should be explicit and configurable through Chef attributes.

## How

Add enrollment attributes to `attributes/client.rb`:
- `enabled`: true (auto-enrollment on)
- `manager_address`: references `node['ossec']['address']`
- `port`: 1515 (default authd port)
- `agent_name`: `node['hostname']`

Additional options (groups, ssl_cipher, certificate paths, etc.) can be overridden via node attributes.

🤖 Generated with [Claude Code](https://claude.ai/code)