### PR TITLE
Add hotfixes inventory item to syscollector wodle

### DIFF
--- a/cookbooks/wazuh_agent/attributes/wodle.rb
+++ b/cookbooks/wazuh_agent/attributes/wodle.rb
@@ -23,6 +23,7 @@ default['ossec']['conf']['wodle'] = [
         'network' => 'yes',
         'packages' => 'yes',
         'ports' => { '@all' => 'no', 'content!' => 'yes'},
-        'processes' => 'yes'
+        'processes' => 'yes',
+        'hotfixes' => 'yes'
      }
 ]

--- a/cookbooks/wazuh_manager/attributes/wodle.rb
+++ b/cookbooks/wazuh_manager/attributes/wodle.rb
@@ -33,6 +33,7 @@ default['ossec']['conf']['wodle'] = [
       'network' => 'yes',
       'packages' => 'yes',
       'ports' => { '@all' => 'no', 'content!' => 'yes'},
-      'processes' => 'yes'
+      'processes' => 'yes',
+      'hotfixes' => 'yes'
    }
 ]


### PR DESCRIPTION
## What

Add hotfixes inventory item to syscollector wodle in both Manager and Agent.

## Why

Wazuh 4.14.0 introduced new syscollector inventory items. The hotfixes item collects installed patches/hotfixes from the system.

## How

Add `hotfixes => yes` to the syscollector wodle section in both `wazuh_manager/attributes/wodle.rb` and `wazuh_agent/attributes/wodle.rb`.

🤖 Generated with [Claude Code](https://claude.ai/code)