### PR TITLE
Update Manager remote and auth settings for Wazuh 4.14.x

### DIFF
--- a/cookbooks/wazuh_manager/attributes/auth.rb
+++ b/cookbooks/wazuh_manager/attributes/auth.rb
@@ -9,10 +9,18 @@ default['ossec']['conf']['auth'] = {
     'use_source_ip' => false,
     'purge' => true,
     'use_password' => false,
-    'limit_maxagents' => true,
     'ciphers' => 'HIGH:!ADH:!EXP:!MD5:!RC4:!3DES:!CAMELLIA:@STRENGTH',
     'ssl_verify_host' => false,
     'ssl_manager_cert' => "#{node['ossec']['dir']}/etc/sslmanager.cert",
     'ssl_manager_key' => "#{node['ossec']['dir']}/etc/sslmanager.key",
-    'ssl_auto_negotiate' => false
+    'ssl_auto_negotiate' => false,
+    'force' => {
+        'enabled' => true,
+        'after_registration_time' => '0',
+        'key_mismatch' => true,
+        'disconnected_time' => {
+            '@enabled' => true,
+            'content!' => '1h'
+        }
+    }
 }

--- a/cookbooks/wazuh_manager/attributes/remote.rb
+++ b/cookbooks/wazuh_manager/attributes/remote.rb
@@ -7,5 +7,9 @@ default['ossec']['conf']['remote'] = {
     'connection' => 'secure',
     'port' => "1514",
     'protocol' => "tcp",
-    'queue_size' => "131072"
+    'queue_size' => "131072",
+    'connection_overtake_time' => '600',
+    'agents' => {
+        'allow_higher_versions' => 'no'
+    }
 }


### PR DESCRIPTION
## What

Update Manager remote and auth configuration attributes for Wazuh 4.14.x.

## Why

New configuration options have been added since Wazuh 4.4.0, and `limit_maxagents` is no longer documented.

## How

- Add `connection_overtake_time` and `agents > allow_higher_versions` to remote config
- Add `force` subsection to auth config for controlling agent re-registration behavior
- Remove `limit_maxagents` (deprecated)

🤖 Generated with [Claude Code](https://claude.ai/code)