### PR TITLE
Update syscheck and localfile settings for Wazuh 4.14.x

### DIFF
--- a/cookbooks/wazuh_agent/attributes/localfile.rb
+++ b/cookbooks/wazuh_agent/attributes/localfile.rb
@@ -50,6 +50,10 @@ if platform_family?('ubuntu', 'debian')
         'log_format' => 'syslog',
         'location' => '/var/log/kern.log'
         }
+    },
+    {
+      'log_format' => 'journald',
+      'location' => 'journald'
     }
   ]
 elsif platform_family?('rhel','centos', 'amazon')

--- a/cookbooks/wazuh_agent/attributes/syscheck.rb
+++ b/cookbooks/wazuh_agent/attributes/syscheck.rb
@@ -29,6 +29,19 @@ default['ossec']['conf']['syscheck']['directories'] = [
 
 default['ossec']['conf']['syscheck']['nodiff'] = '/etc/ssl/private.key'
 default['ossec']['conf']['syscheck']['skip_nfs'] = true
+default['ossec']['conf']['syscheck']['alert_new_files'] = true
+default['ossec']['conf']['syscheck']['max_eps'] = '100'
+default['ossec']['conf']['syscheck']['process_priority'] = '10'
+default['ossec']['conf']['syscheck']['synchronization'] = {
+  'enabled' => true,
+  'interval' => '5m',
+  'max_interval' => '1h',
+  'max_eps' => '10'
+}
+default['ossec']['conf']['syscheck']['file_limit'] = {
+  'enabled' => true,
+  'entries' => '100000'
+}
 
 =begin
 # Syscheck settings

--- a/cookbooks/wazuh_manager/attributes/localfile.rb
+++ b/cookbooks/wazuh_manager/attributes/localfile.rb
@@ -54,6 +54,10 @@ when 'ubuntu', 'debian'
         'log_format' => 'syslog',
         'location' => '/var/log/kern.log'
         }
+    },
+    {
+      'log_format' => 'journald',
+      'location' => 'journald'
     }
   ]
 when 'redhat', 'centos', 'amazon', 'fedora', 'oracle'

--- a/cookbooks/wazuh_manager/attributes/syscheck.rb
+++ b/cookbooks/wazuh_manager/attributes/syscheck.rb
@@ -48,5 +48,9 @@ default['ossec']['conf']['syscheck'] = {
     'interval' => '5m',
     'max_interval' => '1h',
     'max_eps' => '10'
+  },
+  'file_limit' => {
+    'enabled' => true,
+    'entries' => '100000'
   }
 }


### PR DESCRIPTION
## What

Add file_limit to syscheck, sync missing syscheck options to Agent, and add journald log source.

## Why

- `file_limit` controls the maximum number of files monitored by syscheck (added in recent Wazuh)
- Agent syscheck was missing several options present in Manager (alert_new_files, max_eps, process_priority, synchronization)
- journald is a common log source on modern systemd-based distributions (supported since Wazuh 4.9.0)

## How

- Add `file_limit` (enabled, entries: 100000) to both Manager and Agent syscheck
- Add missing syscheck options to Agent to match Manager configuration
- Add journald localfile entry for debian/ubuntu platforms in both Manager and Agent

🤖 Generated with [Claude Code](https://claude.ai/code)