### PR TITLE
Bump release 4.14.5

### DIFF
--- a/cookbooks/wazuh_agent/attributes/version.rb
+++ b/cookbooks/wazuh_agent/attributes/version.rb
@@ -4,4 +4,4 @@
 
 default['wazuh']['major_version'] = "4.x"
 default['wazuh']['minor_version'] = "4.14"
-default['wazuh']['patch_version'] = "4.14.4"
+default['wazuh']['patch_version'] = "4.14.5"

--- a/cookbooks/wazuh_manager/attributes/versions.rb
+++ b/cookbooks/wazuh_manager/attributes/versions.rb
@@ -4,4 +4,4 @@
 
 default['wazuh']['major_version'] = "4.x"
 default['wazuh']['minor_version'] = "4.14"
-default['wazuh']['patch_version'] = "4.14.4"
+default['wazuh']['patch_version'] = "4.14.5"


### PR DESCRIPTION
## 目的・価値

Wazuh を 4.14.4 から 4.14.5 ([2026-04-23 リリース](https://documentation.wazuh.com/current/release-notes/release-4-14-5.html)) に更新します。本リリースには Manager 側の重大なセキュリティ修正が複数含まれており、早期適用によって運用環境のリスクを下げます。

## なぜ必要か

4.14.5 では以下のセキュリティ修正が含まれています。

- DAPI RBAC 権限昇格バイパス (PR#35307)
- Analysisd 正規表現処理のバッファオーバーフロー (PR#35106)
- Authd 認証グループ検証のパストラバーサル (PR#35230)
- Remoted ReadSecMSG サイズ型アンダーフロー (PR#35193)
- クラスター内メモリ割り当て制御 (PR#35173 / PR#35412)
- /events エンドポイントのレート制限バイパス (PR#35077)
- DAPI 呼び出し制限 (PR#34889)

加えて Agent 側の Rootcheck/FIM 偽陽性、macOS Ventura SCA、Office 365 ページネーション、Syscheck レジストリワイルドカード展開のバッファオーバーフロー、API の検証修正なども取り込まれます。

## Chef cookbook への影響

リリースノートに breaking changes はなく、ossec.conf の設定スキーマも変更されていません。Wazuh バイナリ側の不具合修正と内部依存パッケージ更新が中心のため、cookbook 側は `patch_version` 属性の更新のみで対応可能です。

## 実装

- `cookbooks/wazuh_manager/attributes/versions.rb` の `patch_version` を 4.14.5 に更新
- `cookbooks/wazuh_agent/attributes/version.rb` の `patch_version` を 4.14.5 に更新

過去の 4.14.3 → 4.14.4 (cfd2163) と同じ更新パターンです。

[comment by CC]